### PR TITLE
Feature/fabric key fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,6 @@ branches:
   only:
   - master
   - develop
-  - feature/fabricKeyFix
 
 script:
   bash ci.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ branches:
   only:
   - master
   - develop
+  - feature/fabricKeyFix
 
 script:
   bash ci.sh

--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # dhis2-android-dataentry
 An android client which enables users to capture routine, event and tracker data.
+
+Debug builds work out of the box, however for release builds a fabric key is required.
+
+
+For release builds, a fabric key has to be provided to the build process. In order to obtain a fabric key, one has to register for an account at https://fabric.io/.
+The key can be found in fabric under settings/organisations/yourOrganisation > then by clicking on the API eky.
+
+The fabric key should then be put into dhis2-android-dataentry/app/fabric.properties in the build directory:
+apiKey=<your fabric key>
+
+(without <> or quotes)
+Meaning that for forks or clone release builds the builder shsould register for a fabric account and provide that
+fabric key.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -33,8 +33,12 @@ def getFabricKey = {
         Properties properties = new Properties()
         properties.load(fabricPropertiesFile.newDataInputStream())
         return properties.getProperty("apiKey")
-    } else {
+    } else if (System.getenv("DHIS_FABRIC_KEY") != null) {
         return System.getenv("DHIS_FABRIC_KEY")
+    } else {
+        // in case that, neither the environment variable or the properties file is not specified,
+        // return an empty string which will allow to a build debug type of the application.
+        return ""
     }
 }
 


### PR DESCRIPTION
The thought is that it should be easy to try out the application locally.
Such that for example if somebody clones or forks our repository, they could try the app out quickly.

However for a release build and the tests, the builder should have a valid fabric key.